### PR TITLE
Fix database seeding not null constraint error

### DIFF
--- a/db/config.ts
+++ b/db/config.ts
@@ -1,9 +1,9 @@
-import { defineTable, defineDb, column, sql, TRUE } from "astro:db";
-import { nanoid } from "nanoid";
+import { defineTable, defineDb, column } from "astro:db";
 
 export const Posts = defineTable({
   columns: {
-    id: column.text({ primaryKey: true, default: sql`${nanoid(6)}` }),
+    // Let the seed script generate the id instead of relying on a per-row SQL default
+    id: column.text({ primaryKey: true }),
     title: column.text(),
     slug: column.text({ unique: true }),
     pubDate: column.date(),

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,5 +1,5 @@
 import { asDrizzleTable } from "@astrojs/db/utils";
-import { db, FALSE, isDbError } from "astro:db";
+import { db } from "astro:db";
 import { nanoid } from "nanoid";
 import { Posts } from "./config";
 
@@ -10,9 +10,10 @@ export default async function seed() {
     .insert(typeSafePosts)
     .values([
       {
+        id: nanoid(6),
         title: "Hello, World!",
         slug: "hello-world",
-        pubDate: new Date("2024-07-6"),
+        pubDate: new Date("2024-07-06"),
         description:
           "This is the first post of my new Astro blog entitled 'The Garbage Collection'.",
         author: "Joshua Silva",
@@ -24,9 +25,10 @@ export default async function seed() {
         draft: false,
       },
       {
+        id: nanoid(6),
         title: "Hello, World!",
         slug: "hello-world2",
-        pubDate: new Date("2024-07-6"),
+        pubDate: new Date("2024-07-06"),
         description:
           "This is the first post of my new Astro blog entitled 'The Garbage Collection'.",
         author: "Joshua Silva",


### PR DESCRIPTION
Fix "NOT NULL constraint failed" error during DB seeding by generating IDs in the seed script.

The `Posts.id` column's SQL default was built with a JavaScript-only value (`sql\`${nanoid(6)}\``). At seed time, this expression didn't run in SQLite, causing `NULL` values to be inserted and tripping the NOT-NULL / primary-key constraint.

---

[Open in Web](https://cursor.com/agents?id=bc-fd0fd1dd-0841-4604-acff-f869976fbb1f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fd0fd1dd-0841-4604-acff-f869976fbb1f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)